### PR TITLE
fix: Flutter WebでURLを強制的に本番環境に設定

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,19 +1,18 @@
-import 'package:flutter/foundation.dart';
-
 class AppConfig {
   // 環境に応じてサーバーURLを切り替え
   static const bool isProduction = bool.fromEnvironment('dart.vm.product');
   
   static String get serverUrl {
-    // Flutter Webのリリースビルドでは常に本番環境を使用
-    // デバッグ時のみローカルサーバーを使用
-    if (kDebugMode) {
-      // 開発環境: ローカルサーバー
-      return 'http://localhost:3000';
-    } else {
-      // 本番環境: Render.comのURL
-      return 'https://spajam-2025.onrender.com';
-    }
+    // Flutter Web では常に本番環境を使用（一時的な修正）
+    // 本番デプロイ用の設定
+    return 'https://spajam-2025.onrender.com';
+    
+    // 開発時にローカルサーバーを使用したい場合は以下をコメントアウト
+    // if (kDebugMode) {
+    //   return 'http://localhost:3000';
+    // } else {
+    //   return 'https://spajam-2025.onrender.com';
+    // }
   }
   
   static String get apiBaseUrl => '$serverUrl/api';

--- a/lib/services/single_game_service.dart
+++ b/lib/services/single_game_service.dart
@@ -32,6 +32,7 @@ class SingleGameService {
       print('🔗 Connecting to: $baseUrl');
       print('🌍 isProduction: ${AppConfig.isProduction}');
       print('🌐 serverUrl: ${AppConfig.serverUrl}');
+      print('🎯 Final API URL: $baseUrl/game/single/start');
 
       final response = await http.post(
         Uri.parse('$baseUrl/game/single/start'),


### PR DESCRIPTION
- app_config.dartで常にhttps://spajam-2025.onrender.comを使用
- kDebugModeによる判定を一時的に無効化
- single_game_serviceにより詳細なデバッグログを追加
- localhost接続問題を解決